### PR TITLE
update example/discover.cc

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,9 @@ int main(int argc, char *argv[]) {
 	signal(SIGINT, sig_handler);
 	std::string url = "http://your.polaris.cluster:8090";
 	int ret = client.init(url);
-	if (ret != 0) {
-		client.deinit();
+	if (ret != 0)
 		exit(1);
-	}
+
 	task =
 		client.create_discover_task("your.namespace", "your.service.name",
 									RETRY_MAX, polaris_callback);
@@ -117,9 +116,8 @@ int main(int argc, char *argv[]) {
 	signal(SIGINT, sig_handler);
 	std::string url = "http://your.polaris.cluster:8090";
 	int ret = client.init(url);
-	if (ret != 0) {
+	if (ret != 0)
 		exit(1);
-	}
 
 	PolarisConfig config;
 	if (argv[1][0] == 'r') {

--- a/example/discover.cc
+++ b/example/discover.cc
@@ -8,6 +8,7 @@
 #include <signal.h>
 
 #define RETRY_MAX 5
+#define REDIRECT_MAX 3
 #define INSTANCES_NUM 4
 
 using namespace polaris;
@@ -159,7 +160,9 @@ int main(int argc, char *argv[]) {
 					  ":8080?k1_env=v1_base&k2_number=v2_prime#a";
 	fprintf(stderr, "URL : %s\n", url.c_str());
 
-	WFHttpTask *task = WFTaskFactory::create_http_task(url, 3, RETRY_MAX,
+	WFHttpTask *task = WFTaskFactory::create_http_task(url,
+													   REDIRECT_MAX,
+													   RETRY_MAX,
 													   [](WFHttpTask *task) {
 			int state = task->get_state();
 			int error = task->get_error();


### PR DESCRIPTION
**polaris query usage**: 

**scheme://callee_service_namespace.callee_service_name:port?metadata#caller_service_name**

Update example:
```sh
./bazel-bin/example/discover_demo http://POLARIS_CLUSTER_URL:8090
Discover task success.
Successfully add PolarisPolicy: default.workflow.polaris.service.b
URL : http://default.workflow.polaris.service.b:8080?k1_env=v1_base&k2_number=v2_prime#a
Query task callback. state = 0 error = 0
Response from instance 127.0.0.0.1:8002
Success. Press Ctrl-C to exit.
```
