### PR TITLE
Support meta router.

### DIFF
--- a/src/PolarisPolicies.cc
+++ b/src/PolarisPolicies.cc
@@ -586,12 +586,15 @@ bool PolarisPolicy::split_fragment(const char *fragment,
 		}
 	}
 
-	pos = caller_info.find(".");
-	if (pos == std::string::npos)
-		return false;
+	if (this->config.enable_rule_base_router)
+	{
+		pos = caller_info.find(".");
+		if (pos == std::string::npos)
+			return false;
 
-	caller_namespace = caller_info.substr(0, pos);
-	caller_name = caller_info.substr(pos + 1);
+		caller_namespace = caller_info.substr(0, pos);
+		caller_name = caller_info.substr(pos + 1);
+	}
 
 	return true;
 }

--- a/src/PolarisPolicies.cc
+++ b/src/PolarisPolicies.cc
@@ -24,6 +24,8 @@ PolarisPolicyConfig::PolarisPolicyConfig(const std::string& service_name) :
 {
 	this->enable_rule_base_router = true;
 	this->enable_nearby_based_router = true;
+	this->enable_dst_meta_router = false;
+	this->failover_type = MetadataFailoverNone;
 }
 
 PolarisInstanceParams::PolarisInstanceParams(const struct instance *inst,
@@ -202,11 +204,21 @@ bool PolarisPolicy::select(const ParsedURI& uri, WFNSTracing *tracing,
 
 	if (meta.size())
 	{
-		this->matching_bounds(caller_name, caller_namespace, meta, &dst_bounds);
-		if (dst_bounds && dst_bounds->size())
+		// will be refactored as chain mode
+		if (this->config.enable_rule_base_router)
+		{
+			this->matching_bounds(caller_name, caller_namespace, meta, &dst_bounds);
+			if (dst_bounds && dst_bounds->size())
+			{
+				pthread_rwlock_rdlock(&this->rwlock);
+				ret = this->matching_subset(dst_bounds, matched_subset);
+				pthread_rwlock_unlock(&this->rwlock);
+			}
+		}
+		else if (this->config.enable_dst_meta_router)
 		{
 			pthread_rwlock_rdlock(&this->rwlock);
-			ret = this->matching_subset(dst_bounds, matched_subset);
+			ret = this->matching_meta(meta, matched_subset);
 			pthread_rwlock_unlock(&this->rwlock);
 		}
 	}
@@ -257,7 +269,6 @@ void PolarisPolicy::matching_bounds(
 					std::vector<struct destination_bound> **dst_bounds)
 {
 	std::vector<struct destination_bound> *dst = NULL;
-	bool ret = true;
 
 	pthread_rwlock_t *lock = &this->inbound_rwlock;
 	pthread_rwlock_rdlock(lock);
@@ -423,10 +434,11 @@ bool PolarisPolicy::matching_instances(struct destination_bound *dst_bounds,
 		if (dst_bounds->service_namespace != params->get_namespace())
 			continue;
 
+		const auto &inst_meta = params->get_meta();
 		flag = true;
+
 		for (const auto &bound_meta : dst_bounds->metadata)
 		{
-			const auto &inst_meta = params->get_meta();
 			const auto inst_meta_it = inst_meta.find(bound_meta.first);
 
 			if (inst_meta_it == inst_meta.end() ||
@@ -475,6 +487,7 @@ bool PolarisPolicy::matching_rules(
 	return true;
 }
 
+// get_one will be replaced with nearby or others
 EndpointAddress *PolarisPolicy::get_one(
 		const std::vector<EndpointAddress *>& instances,
 		WFNSTracing *tracing)
@@ -501,7 +514,7 @@ EndpointAddress *PolarisPolicy::get_one(
 
 	for (i = 0; i < instances.size(); i++)
 	{
-		if (instances[i]->fail_count > instances[i]->params->max_fails)
+		if (this->check_server_health(instances[i]) == false)
 			continue;
 
 		params = static_cast<PolarisInstanceParams *>(instances[i]->params);
@@ -516,7 +529,12 @@ EndpointAddress *PolarisPolicy::get_one(
 	return instances[i];
 }
 
-// fragment format: #k1=v1&k2=v2&caller_namespace.caller_name
+/*
+ * fragment format: #k1=v1&k2=v2&caller_namespace.caller_name
+ *
+ * if kv pair is for meta router, add "meta" as prefix of each key:
+ * 					#meta.k1=v1&meta.k2=v2&caller_namespace.caller_name
+ */
 bool PolarisPolicy::split_fragment(const char *fragment,
 								   std::string& caller_name,
 								   std::string& caller_namespace,
@@ -527,6 +545,7 @@ bool PolarisPolicy::split_fragment(const char *fragment,
 
 	std::string caller_info = fragment;
 	std::vector<std::string> arr = StringUtil::split(caller_info, '&');
+	std::size_t pos;
 
 	if (!arr.empty())
 	{
@@ -549,11 +568,25 @@ bool PolarisPolicy::split_fragment(const char *fragment,
 			if (meta.count(kv[0]) > 0)
 				continue;
 
-			meta.emplace(std::move(kv[0]), std::move(kv[1]));
+			// If rule_base_router enable, key "meta.xxx" means "meta.xxx".
+			// If dst_meta_router enable, key "meta.xxx" means "xxx".
+			if (this->config.enable_dst_meta_router)
+			{
+				pos = kv[0].find("meta.");
+				if (pos == std::string::npos)
+					continue;
+				else
+				{
+					meta.emplace(std::move(kv[0].substr(pos + 1)),
+								 std::move(kv[1]));
+				}
+			}
+			else
+				meta.emplace(std::move(kv[0]), std::move(kv[1]));
 		}
 	}
 
-	std::size_t pos = caller_info.find(".");
+	pos = caller_info.find(".");
 	if (pos == std::string::npos)
 		return false;
 
@@ -563,6 +596,122 @@ bool PolarisPolicy::split_fragment(const char *fragment,
 	return true;
 }
 
+bool PolarisPolicy::check_server_health(const EndpointAddress *addr)
+{
+	PolarisInstanceParams *params = static_cast<PolarisInstanceParams *>(addr->params);
+
+	if (params->get_healthy() == false || addr->fail_count > params->max_fails)
+		return false;
+
+	return true;
+}
+
+/*
+ * Match instance by meta.
+ * 1. if some instances are healthy, return them;
+ * 2. else if all nstances are unheathy, return them, too;
+ * 3. else use failover strategy.
+ */
+bool PolarisPolicy::matching_meta(const std::map<std::string, std::string>& meta,
+								  std::vector<EndpointAddress *>& subset)
+{
+	PolarisInstanceParams *params;
+	bool flag;
+	std::vector<EndpointAddress *> unhealthy;
+
+	for (size_t i = 0; i < this->servers.size(); i++)
+	{
+		params = static_cast<PolarisInstanceParams *>(this->servers[i]->params);
+		const auto &inst_meta = params->get_meta();
+		flag = true;
+
+		for (const auto &kv : meta)
+		{
+			const auto inst_meta_it = inst_meta.find(kv.first);
+
+			if (inst_meta_it == inst_meta.end() ||
+				kv.second != inst_meta_it->second)
+			{
+				flag = false;
+				break;
+			}
+		}
+
+		if (flag == true)
+		{
+			if (this->check_server_health(this->servers[i]))
+				subset.push_back(this->servers[i]);
+			else
+				unhealthy.push_back(this->servers[i]);
+		}
+	}
+
+	if (subset.size())
+		return true;
+
+	if (unhealthy.size())
+	{
+		subset.swap(unhealthy);
+		return true;
+	}
+
+	switch (this->config.failover_type)
+	{
+	case MetadataFailoverAll:
+		subset = this->servers;
+		return true;
+	case MetadataFailoverNotKey:
+		return this->matching_meta_notkey(meta, subset);
+	default:
+		break;
+	}
+
+	return false;
+}
+
+// find instances which don`t contain any keys in meta
+bool PolarisPolicy::matching_meta_notkey(const std::map<std::string, std::string>& meta,
+										 std::vector<EndpointAddress *>& subset)
+{
+	PolarisInstanceParams *params;
+	bool flag;
+	std::vector<EndpointAddress *> unhealthy;
+
+	for (size_t i = 0; i < this->servers.size(); i++)
+	{
+		params = static_cast<PolarisInstanceParams *>(this->servers[i]->params);
+		const auto &inst_meta = params->get_meta();
+		flag = true;
+
+		for (const auto &kv : meta)
+		{
+			if (inst_meta.find(kv.first) == inst_meta.end())
+			{
+				flag = false;
+				break;
+			}
+		}
+
+		if (flag == true)
+		{
+			if (this->check_server_health(this->servers[i]))
+				subset.push_back(this->servers[i]);
+			else
+				unhealthy.push_back(this->servers[i]);
+		}
+	}
+
+	if (subset.size())
+		return true;
+
+	if (unhealthy.size())
+	{
+		subset.swap(unhealthy);
+		return true;
+	}
+
+	return false;
+}
 
 }; // namespace polaris
 

--- a/src/PolarisPolicies.cc
+++ b/src/PolarisPolicies.cc
@@ -609,7 +609,7 @@ bool PolarisPolicy::check_server_health(const EndpointAddress *addr)
 /*
  * Match instance by meta.
  * 1. if some instances are healthy, return them;
- * 2. else if all nstances are unheathy, return them, too;
+ * 2. else if all instances are unheathy, return them, too;
  * 3. else use failover strategy.
  */
 bool PolarisPolicy::matching_meta(const std::map<std::string, std::string>& meta,
@@ -685,7 +685,7 @@ bool PolarisPolicy::matching_meta_notkey(const std::map<std::string, std::string
 
 		for (const auto &kv : meta)
 		{
-			if (inst_meta.find(kv.first) == inst_meta.end())
+			if (inst_meta.find(kv.first) != inst_meta.end())
 			{
 				flag = false;
 				break;

--- a/src/PolarisPolicies.h
+++ b/src/PolarisPolicies.h
@@ -14,6 +14,12 @@
 
 namespace polaris {
 
+typedef enum MetadataFailoverType {
+	MetadataFailoverNone, // default
+	MetadataFailoverAll,  // return all instances
+	MetadataFailoverNotKey,
+} MetadataFailoverType;
+
 /*
 struct MatchingString
 {
@@ -45,7 +51,9 @@ private:
 	std::string location_region;
 	std::string location_campus;
 	bool enable_rule_base_router;
+	bool enable_dst_meta_router;
 	bool enable_nearby_based_router;
+	MetadataFailoverType failover_type;
 
 public:
 	PolarisPolicyConfig(const std::string& service_name);
@@ -54,6 +62,45 @@ public:
 	{
 		return this->service_name;
 	}
+
+	void set_rule_base_router_enable()
+	{
+		this->enable_rule_base_router = true;
+		this->enable_dst_meta_router = false;
+	}
+
+	void set_dst_meta_router_enable()
+	{
+		this->enable_dst_meta_router = true;
+		this->enable_rule_base_router = false;
+	}
+
+	void set_rule_base_router_disable()
+	{
+		this->enable_rule_base_router = false;
+	}
+
+	void set_dst_meta_router_disable()
+	{
+		this->enable_dst_meta_router = false;
+	}
+
+	void set_nearby_based_router_enable()
+	{
+		this->enable_nearby_based_router = true;
+	}
+
+	void set_nearby_based_router_disable()
+	{
+		this->enable_nearby_based_router = false;
+	}
+
+	void set_failover_type(MetadataFailoverType type)
+	{
+		this->failover_type = type;
+	}
+
+	friend class PolarisPolicy;
 };
 
 class PolarisInstanceParams : public PolicyAddrParams
@@ -65,6 +112,7 @@ public:
 	{
 		return this->metadata;
 	}
+	bool get_healthy() const { return this->healthy; }
 
 public:
 	PolarisInstanceParams(const struct instance *inst,
@@ -130,6 +178,11 @@ private:
 	bool matching_instances(struct destination_bound *dst_bounds,
 							std::vector<EndpointAddress *>& subsets);
 
+	bool matching_meta(const std::map<std::string, std::string>& meta,
+					   std::vector<EndpointAddress *>& subset);
+	bool matching_meta_notkey(const std::map<std::string, std::string>& meta,
+							  std::vector<EndpointAddress *>& subset);
+
 	size_t subsets_weighted_random(
 			const std::vector<struct destination_bound *>& bounds,
 			const std::vector<std::vector<EndpointAddress *>>& subsets);
@@ -141,6 +194,8 @@ private:
 						std::string& caller_name,
 						std::string& caller_namespace,
 						std::map<std::string, std::string>& meta);
+
+	bool check_server_health(const EndpointAddress *addr);
 };
 
 }; // namespace polaris

--- a/src/PolarisPolicies.h
+++ b/src/PolarisPolicies.h
@@ -112,7 +112,7 @@ private:
 	virtual void add_server_locked(EndpointAddress *addr);
 	void clear_instances_locked();
 
-	bool matching_bounds(const std::string& caller_service_name,
+	void matching_bounds(const std::string& caller_name,
 						 const std::string& caller_namespace,
 						 const std::map<std::string, std::string>& meta,
 						 std::vector<struct destination_bound> **dst_bounds);
@@ -138,9 +138,9 @@ private:
 							 WFNSTracing *tracing);
 
 	bool split_fragment(const char *fragment,
-						std::map<std::string, std::string>& meta,
 						std::string& caller_name,
-						std::string& caller_namespace);
+						std::string& caller_namespace,
+						std::map<std::string, std::string>& meta);
 };
 
 }; // namespace polaris

--- a/src/PolarisPolicies.h
+++ b/src/PolarisPolicies.h
@@ -14,11 +14,11 @@
 
 namespace polaris {
 
-typedef enum MetadataFailoverType {
+enum MetadataFailoverType {
 	MetadataFailoverNone, // default
 	MetadataFailoverAll,  // return all instances
 	MetadataFailoverNotKey,
-} MetadataFailoverType;
+};
 
 /*
 struct MatchingString
@@ -53,7 +53,7 @@ private:
 	bool enable_rule_base_router;
 	bool enable_dst_meta_router;
 	bool enable_nearby_based_router;
-	MetadataFailoverType failover_type;
+	enum MetadataFailoverType failover_type;
 
 public:
 	PolarisPolicyConfig(const std::string& service_name);
@@ -63,39 +63,28 @@ public:
 		return this->service_name;
 	}
 
-	void set_rule_base_router_enable()
+	void set_rule_base_router(bool flag)
 	{
-		this->enable_rule_base_router = true;
-		this->enable_dst_meta_router = false;
+		this->enable_rule_base_router = flag;
+
+		if (flag)
+			this->enable_dst_meta_router = false;
 	}
 
-	void set_dst_meta_router_enable()
+	void set_dst_meta_router(bool flag)
 	{
-		this->enable_dst_meta_router = true;
-		this->enable_rule_base_router = false;
+		this->enable_dst_meta_router = flag;
+
+		if (flag)
+			this->enable_rule_base_router = false;
 	}
 
-	void set_rule_base_router_disable()
+	void set_nearby_based_router(bool flag)
 	{
-		this->enable_rule_base_router = false;
+		this->enable_nearby_based_router = flag;
 	}
 
-	void set_dst_meta_router_disable()
-	{
-		this->enable_dst_meta_router = false;
-	}
-
-	void set_nearby_based_router_enable()
-	{
-		this->enable_nearby_based_router = true;
-	}
-
-	void set_nearby_based_router_disable()
-	{
-		this->enable_nearby_based_router = false;
-	}
-
-	void set_failover_type(MetadataFailoverType type)
+	void set_failover_type(enum MetadataFailoverType type)
 	{
 		this->failover_type = type;
 	}

--- a/test/polaris_policy_unittest.cc
+++ b/test/polaris_policy_unittest.cc
@@ -484,11 +484,35 @@ TEST(polaris_policy_unittest, select)
 	EndpointAddress *addr;
 	ParsedURI uri;
 
-	std::string url = "http://b:8080?k1_env=v1_base&k2_number=v2_prime#a";
+	std::string url = "http://b_namespace.b:8080#k1_env=v1_base&k2_number=v2_prime&a_namespace.a";
 	EXPECT_EQ(URIParser::parse(url, uri), 0);
 
 	pp.select(uri, NULL, &addr);
 	EXPECT_EQ(atoi(addr->port.c_str()), 8002);
+}
+
+TEST(polaris_policy_unittest, meta_router)
+{
+	std::vector<struct routing_bound> routing_inbounds;
+	fill_inbounds_a_b(routing_inbounds);
+
+	std::vector<struct instance> instances;
+	fill_instances(instances);
+
+	conf.set_dst_meta_router_enable();
+	PolarisPolicy pp(&conf);
+	pp.update_instances(instances);
+	pp.update_inbounds(routing_inbounds);
+
+	EndpointAddress *addr;
+	ParsedURI uri;
+
+	std::string url = "http://b_namespace.b:8080#meta.k1=v1&meta.k2=v2&a_namespace.a";
+	EXPECT_EQ(URIParser::parse(url, uri), 0);
+
+	pp.select(uri, NULL, &addr);
+	EXPECT_EQ(atoi(addr->port.c_str()), 8003);
+	conf.set_rule_base_router_enable();
 }
 
 int main(int argc, char* argv[])

--- a/test/polaris_policy_unittest.cc
+++ b/test/polaris_policy_unittest.cc
@@ -435,6 +435,38 @@ TEST(polaris_policy_unittest, matching_subset)
 			EXPECT_TRUE(false);
 	}
 }
+
+TEST(polaris_policy_unittest, split_fragment)
+{
+	PolarisPolicy pp(&conf);
+
+	std::string caller_name;
+	std::string caller_namespace;
+	std::map<std::string, std::string> meta;
+	const char *fragment = "k1=v1&k2=v2&caller_namespace.caller_name";
+
+	EXPECT_TRUE(pp.split_fragment(fragment, meta, caller_name, caller_namespace));
+	EXPECT_EQ(meta.size(), 2);
+	EXPECT_TRUE(caller_name == "caller_name");
+	EXPECT_TRUE(caller_namespace == "caller_namespace");
+
+	fragment = "k1=v1&caller_namespace.";
+	EXPECT_FALSE(pp.split_fragment(fragment, meta, caller_name, caller_namespace));
+
+	fragment = "k1=v1&.";
+	EXPECT_FALSE(pp.split_fragment(fragment, meta, caller_name, caller_namespace));
+
+	fragment = "k1=v1&k2=&caller_namespace.caller_name";
+	EXPECT_FALSE(pp.split_fragment(fragment, meta, caller_name, caller_namespace));
+
+	caller_name.clear();
+	caller_namespace.clear();
+	meta.clear();
+	fragment = "*.*";
+	EXPECT_TRUE(pp.split_fragment(fragment, meta, caller_name, caller_namespace));
+	EXPECT_TRUE(caller_name == "*");
+	EXPECT_TRUE(caller_namespace == "*");
+}
 */
 
 TEST(polaris_policy_unittest, select)

--- a/test/polaris_policy_unittest.cc
+++ b/test/polaris_policy_unittest.cc
@@ -507,7 +507,7 @@ TEST(polaris_policy_unittest, meta_router)
 	EndpointAddress *addr;
 	ParsedURI uri;
 
-	std::string url = "http://b_namespace.b:8080#meta.k1=v1&meta.k2=v2&a_namespace.a";
+	std::string url = "http://b_namespace.b:8080#meta.k1=v1&meta.k2=v2";
 	EXPECT_EQ(URIParser::parse(url, uri), 0);
 
 	pp.select(uri, NULL, &addr);

--- a/test/polaris_policy_unittest.cc
+++ b/test/polaris_policy_unittest.cc
@@ -499,20 +499,25 @@ TEST(polaris_policy_unittest, meta_router)
 	std::vector<struct instance> instances;
 	fill_instances(instances);
 
-	conf.set_dst_meta_router_enable();
+	conf.set_dst_meta_router(true);
 	PolarisPolicy pp(&conf);
 	pp.update_instances(instances);
 	pp.update_inbounds(routing_inbounds);
 
 	EndpointAddress *addr;
 	ParsedURI uri;
-
 	std::string url = "http://b_namespace.b:8080#meta.k1=v1&meta.k2=v2";
 	EXPECT_EQ(URIParser::parse(url, uri), 0);
 
 	pp.select(uri, NULL, &addr);
 	EXPECT_EQ(atoi(addr->port.c_str()), 8003);
-	conf.set_rule_base_router_enable();
+
+	url = "http://b_namespace.b:8080#meta.k1=v1";
+	EXPECT_EQ(URIParser::parse(url, uri), 0);
+
+	pp.select(uri, NULL, &addr);
+	EXPECT_EQ(atoi(addr->port.c_str()), 8002);
+	conf.set_rule_base_router(true);
 }
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
**dst_meta_router** is parallel with **rule_base_router**, which are enabled by PolarisConfig.  We need to distinguish **labels** and **metas** in **URL**  like the following:

fragment such as: 
`#k1=v1&k2=v2&caller_namespace.caller_name`
and we will get label pairs <k1,v1> and <k2,v2> for **rule_base_router**.

fragment such as: 
`#meta.k1=v1&meta.k2=v2`
and we will get meta pairs <k1,v1> and <k2,v2> for **dst_meta_router**.

**caller_namespace** and **caller_name** are required for **rule_base_router** but useless for **dst_meta_router**.

Also, if enable **rule_base_router**, key "meta.xxx" means "meta.xxx".
But if enable **dst_meta_router**, key "meta.xxx" means "xxx".