### PR TITLE
support nearby_base_router

### DIFF
--- a/src/PolarisConfig.cc
+++ b/src/PolarisConfig.cc
@@ -712,6 +712,7 @@ int init_consumer_from_yaml(struct polaris_config *ptr, const YAML::Node &node) 
                 ptr->nearby_unhealthy_degrade_percent =
                     nearby["unhealthyPercentToDegrade"].as<int>(100);
                 ptr->nearby_enable_recover_all = nearby["enableRecoverAll"].as<bool>(true);
+                ptr->nearby_strict_nearby = nearby["strictNearby"].as<bool>(false);
             }
         }
     }

--- a/src/PolarisConfig.h
+++ b/src/PolarisConfig.h
@@ -135,6 +135,8 @@ struct polaris_config {
     int nearby_unhealthy_degrade_percent;
     // 允许全死全活
     bool nearby_enable_recover_all;
+    // 严格就近配置
+    bool nearby_strict_nearby;
 
     // polaris rateLimiter config
     std::string rate_limit_mode;
@@ -367,12 +369,12 @@ class PolarisInstance {
         instance_init();
     }
 
-	PolarisInstance(const PolarisInstance &copy) {
-		this->~PolarisInstance();
-		this->ref = copy.ref;
-		this->inst = copy.inst;
-		++*this->ref;
-	}
+    PolarisInstance(const PolarisInstance &copy) {
+        this->~PolarisInstance();
+        this->ref = copy.ref;
+        this->inst = copy.inst;
+        ++*this->ref;
+    }
 
     PolarisInstance(PolarisInstance &&move) {
         this->ref = move.ref;
@@ -383,10 +385,12 @@ class PolarisInstance {
     }
 
     PolarisInstance &operator=(const PolarisInstance &copy) {
-        this->~PolarisInstance();
-        this->ref = copy.ref;
-        this->inst = copy.inst;
-        ++*this->ref;
+        if (this != &copy) {
+            this->~PolarisInstance();
+            this->ref = copy.ref;
+            this->inst = copy.inst;
+            ++*this->ref;
+        }
         return *this;
     }
 
@@ -589,6 +593,7 @@ class PolarisConfig {
         return this->ptr->nearby_unhealthy_degrade_percent;
     }
     bool get_nearby_enable_recover_all() const { return this->ptr->nearby_enable_recover_all; }
+    bool get_nearby_strict_nearby() const { return this->ptr->nearby_strict_nearby; }
     std::string get_rate_limit_mode() const { return this->ptr->rate_limit_mode; }
     std::string get_rate_limit_cluster_namespace() const {
         return this->ptr->rate_limit_cluster_namespace;
@@ -670,6 +675,7 @@ class PolarisConfig {
         this->ptr->nearby_unhealthy_degrade = true;
         this->ptr->nearby_unhealthy_degrade_percent = 100;
         this->ptr->nearby_enable_recover_all = true;
+        this->ptr->nearby_strict_nearby = false;
     }
 
     void polaris_config_init_ratelimiter() {

--- a/src/PolarisManager.cc
+++ b/src/PolarisManager.cc
@@ -84,7 +84,7 @@ PolarisManager::PolarisManager(const std::string& polaris_url)
 }
 
 PolarisManager::PolarisManager(const std::string& polaris_url,
-							   const std::string &yaml_file)
+							   const std::string& yaml_file)
 {
 	PolarisConfig config;
 	config.init_from_yaml(yaml_file);

--- a/src/PolarisManager.h
+++ b/src/PolarisManager.h
@@ -38,7 +38,7 @@ class PolarisManager
 public:
 	PolarisManager(const std::string& polaris_url);
 	PolarisManager(const std::string& polaris_url,
-				   const std::string &yaml_file);
+				   const std::string& yaml_file);
 	~PolarisManager();
 
 	int watch_service(const std::string& service_namespace,

--- a/src/PolarisPolicies.cc
+++ b/src/PolarisPolicies.cc
@@ -1,4 +1,5 @@
 #include <set>
+#include <string.h>
 #include "workflow/StringUtil.h"
 #include "PolarisPolicies.h"
 
@@ -38,12 +39,12 @@ PolarisPolicyConfig::PolarisPolicyConfig(const std::string& policy_name,
 		else if (router == "nearbyBasedRouter")
 		{
 			this->set_nearby_based_router(true,
-										  conf.get_nearby_match_level(),
-										  conf.get_nearby_max_match_level(),
-										  conf.get_nearby_unhealthy_degrade() == true ?
-										  conf.get_nearby_unhealthy_degrade_percent() : 0,
-										  conf.get_nearby_enable_recover_all(),
-										  true /* strict nearby */);
+								conf.get_nearby_match_level(),
+								conf.get_nearby_max_match_level(),
+								conf.get_nearby_unhealthy_degrade() == true ?
+								conf.get_nearby_unhealthy_degrade_percent() : 100,
+								conf.get_nearby_enable_recover_all(),
+								conf.get_nearby_strict_nearby());
 		}
 	}
 
@@ -62,7 +63,7 @@ void PolarisPolicyConfig::set_nearby_based_router(bool flag,
 												 bool enable_recover_all,
 												 bool strict_nearby)
 {
-	this->enable_nearby_based_router = flag;
+	this->enable_nearby_based_router = true;
 
 	if (match_level == "zone")
 		this->nearby_match_level = NearbyMatchLevelZone;
@@ -70,6 +71,8 @@ void PolarisPolicyConfig::set_nearby_based_router(bool flag,
 		this->nearby_match_level = NearbyMatchLevelCampus;
 	else if (match_level == "region")
 		this->nearby_match_level = NearbyMatchLevelRegion;
+	else
+		this->nearby_match_level = NearbyMatchLevelNone;
 
 	if (max_match_level == "zone")
 		this->nearby_max_match_level = NearbyMatchLevelZone;
@@ -77,10 +80,12 @@ void PolarisPolicyConfig::set_nearby_based_router(bool flag,
 		this->nearby_max_match_level = NearbyMatchLevelCampus;
 	else if (max_match_level == "region")
 		this->nearby_max_match_level = NearbyMatchLevelRegion;
+	else
+		this->nearby_max_match_level = NearbyMatchLevelNone;
 
 	this->nearby_unhealthy_percentage = percentage;
 	this->nearby_enable_recover_all = enable_recover_all;
-	this->strict_nearby = strict_nearby;
+	this->nearby_strict_nearby = strict_nearby;
 }
 
 PolarisInstanceParams::PolarisInstanceParams(const struct instance *inst,
@@ -94,6 +99,9 @@ PolarisInstanceParams::PolarisInstanceParams(const struct instance *inst,
 	this->enable_healthcheck = inst->enable_healthcheck;
 	this->healthy = inst->healthy;
 	this->isolate = inst->isolate;
+	this->region = inst->region;
+	this->zone = inst->zone;
+	this->campus = inst->campus;
 
 	this->weight = inst->weight;
 	// params.weight will not affect here
@@ -283,11 +291,11 @@ bool PolarisPolicy::select(const ParsedURI& uri, WFNSTracing *tracing,
 		pthread_rwlock_rdlock(&this->rwlock);
 		if (matched_subset.size())
 		{
-			*addr = this->get_one(matched_subset, tracing);
+			EndpointAddress *one = this->get_one(matched_subset, tracing);
 
 			for (size_t i = 0; i < matched_subset.size(); i++)
 			{
-				if (*addr != matched_subset[i])
+				if (one != matched_subset[i])
 				{
 					if (--matched_subset[i]->ref == 0)
 					{
@@ -296,11 +304,22 @@ bool PolarisPolicy::select(const ParsedURI& uri, WFNSTracing *tracing,
 					}
 				}
 			}
+
+			if (one)
+				*addr = one;
+			else
+				ret = false;
 		}
 		else if (this->servers.size())
 		{
-			*addr = this->get_one(this->servers, tracing);
-			++(*addr)->ref;
+			EndpointAddress *one = this->get_one(this->servers, tracing);
+			if (one)
+			{
+				*addr = one;
+				++(*addr)->ref;
+			}
+			else
+				ret = false;
 		}
 		else
 			ret = false;
@@ -541,15 +560,113 @@ bool PolarisPolicy::matching_rules(
 	return true;
 }
 
-// get_one will be replaced with nearby or others
+bool inline PolarisPolicy::nearby_match_level(const PolarisInstanceParams *params,
+											  NearbyMatchLevelType level)
+{
+	switch (level)
+	{
+	case NearbyMatchLevelZone:
+		if (strcasecmp(this->config.location_zone.c_str(),
+					   params->get_zone().c_str()) == 0 &&
+			strcasecmp(this->config.location_region.c_str(),
+					   params->get_region().c_str()) == 0)
+		return true;
+
+	case NearbyMatchLevelCampus:
+		if (strcasecmp(this->config.location_campus.c_str(),
+					   params->get_campus().c_str()) == 0 &&
+			strcasecmp(this->config.location_zone.c_str(),
+					   params->get_zone().c_str()) == 0 &&
+			strcasecmp(this->config.location_region.c_str(),
+					   params->get_region().c_str()) == 0)
+		return true;
+
+	case NearbyMatchLevelRegion:
+		if (strcasecmp(this->config.location_region.c_str(),
+					   params->get_region().c_str()) == 0)
+		return true;
+
+	default:
+		break;
+	}
+
+	return false;
+}
+
+bool PolarisPolicy::nearby_router_filter(
+						std::vector<EndpointAddress *>& instances)
+{
+	std::vector<EndpointAddress *> nearby_inst;
+	PolarisInstanceParams *params;
+	int unhealty_count = 0;
+
+	if (this->config.nearby_strict_nearby &&
+		this->config.location_region.empty() &&
+		this->config.location_zone.empty() &&
+		this->config.location_campus.empty())
+	{
+		return false;
+	}
+
+	// 1. match_level
+	for (size_t i = 0; i < instances.size(); i++)
+	{
+		params = static_cast<PolarisInstanceParams *>(instances[i]->params);
+		if (this->nearby_match_level(params, this->config.nearby_match_level))
+		{
+			nearby_inst.push_back(instances[i]);
+			unhealty_count += !this->check_server_health(instances[i]) ? 1 : 0;
+		}
+	}
+
+	// 2. max_match_level
+	if (this->config.nearby_max_match_level != NearbyMatchLevelNone &&
+		!this->config.nearby_strict_nearby &&
+		// 3. check degrade
+		(nearby_inst.size() == 0 ||
+		unhealty_count * 100 / (int)nearby_inst.size() >
+		this->config.nearby_unhealthy_percentage))
+	{
+		for (size_t i = 0; i < instances.size(); i++)
+		{
+			params = static_cast<PolarisInstanceParams *>(instances[i]->params);
+			if (this->nearby_match_level(params,
+										 this->config.nearby_max_match_level))
+			{
+				nearby_inst.push_back(instances[i]);
+			}
+		}
+	}
+
+	// 4. check enable_recover_all
+	if (nearby_inst.size() == 0)
+	{
+		if (this->config.nearby_enable_recover_all &&
+			!this->config.nearby_strict_nearby)
+		{
+			return true;
+		}
+		return false;
+	}
+
+	instances.assign(nearby_inst.begin(), nearby_inst.end());
+	return true;
+}
+
 EndpointAddress *PolarisPolicy::get_one(
-		const std::vector<EndpointAddress *>& instances,
-		WFNSTracing *tracing)
+						std::vector<EndpointAddress *>& instances,
+						WFNSTracing *tracing)
 {
 	int x, s = 0;
 	int total_weight = 0;	
 	size_t i;
 	PolarisInstanceParams *params;
+
+	if (this->config.enable_nearby_based_router)
+	{
+		if (!this->nearby_router_filter(instances))
+			return NULL;
+	}
 
 	for (i = 0; i < instances.size(); i++)
 	{

--- a/src/PolarisPolicies.cc
+++ b/src/PolarisPolicies.cc
@@ -57,8 +57,8 @@ PolarisPolicyConfig::PolarisPolicyConfig(const std::string& policy_name,
 }
 
 void PolarisPolicyConfig::set_nearby_based_router(bool enable,
-												 std::string match_level,
-												 std::string max_match_level,
+												 const std::string& match_level,
+												 const std::string& max_match_level,
 												 short percentage,
 												 bool enable_recover_all,
 												 bool strict_nearby)
@@ -618,7 +618,7 @@ bool PolarisPolicy::nearby_router_filter(
 		return false;
 	}
 
-	for (auto inst : instances)
+	for (EndpointAddress *inst : instances)
 	{
 		if (this->nearby_match_level(inst, this->config.nearby_match_level))
 		{
@@ -630,7 +630,7 @@ bool PolarisPolicy::nearby_router_filter(
 	if (this->nearby_match_degrade(unhealthy_count, nearby_inst.size()))
 	{
 		nearby_inst.clear();
-		for (auto inst : instances)
+		for (EndpointAddress *inst : instances)
 		{
 			if (this->nearby_match_level(inst,
 										 this->config.nearby_max_match_level))

--- a/src/PolarisPolicies.cc
+++ b/src/PolarisPolicies.cc
@@ -56,14 +56,14 @@ PolarisPolicyConfig::PolarisPolicyConfig(const std::string& policy_name,
 		this->location_campus = conf.get_api_location_campus();
 }
 
-void PolarisPolicyConfig::set_nearby_based_router(bool flag,
+void PolarisPolicyConfig::set_nearby_based_router(bool enable,
 												 std::string match_level,
 												 std::string max_match_level,
 												 short percentage,
 												 bool enable_recover_all,
 												 bool strict_nearby)
 {
-	this->enable_nearby_based_router = true;
+	this->enable_nearby_based_router = enable;
 
 	if (match_level == "zone")
 		this->nearby_match_level = NearbyMatchLevelZone;

--- a/src/PolarisPolicies.h
+++ b/src/PolarisPolicies.h
@@ -64,7 +64,7 @@ private:
 	// for ruleBaseRouter
 	enum NearbyMatchLevelType nearby_match_level;
 	enum NearbyMatchLevelType nearby_max_match_level;
-	short nearby_unhealthy_percentage;
+	unsigned short nearby_unhealthy_percentage;
 	bool nearby_enable_recover_all;
 	bool nearby_strict_nearby;
 
@@ -193,8 +193,9 @@ private:
 	EndpointAddress *get_one(std::vector<EndpointAddress *>& instances,
 							 WFNSTracing *tracing);
 	bool nearby_router_filter(std::vector<EndpointAddress *>& instances);
-	bool nearby_match_level(const PolarisInstanceParams *params,
+	bool nearby_match_level(const EndpointAddress *instance,
 							NearbyMatchLevelType level);
+	bool nearby_match_degrade(size_t unhealth, size_t total);
 
 	bool split_fragment(const char *fragment,
 						std::string& caller_name,

--- a/src/PolarisPolicies.h
+++ b/src/PolarisPolicies.h
@@ -88,9 +88,12 @@ public:
 			this->enable_rule_base_router = false;
 	}
 
-	void set_nearby_based_router(bool enable, std::string match_level,
-								 std::string max_match_level, short percentage,
-								 bool enable_recover_all, bool strict_nearby);
+	void set_nearby_based_router(bool enable,
+								 const std::string& match_level,
+								 const std::string& max_match_level,
+								 short percentage,
+								 bool enable_recover_all,
+								 bool strict_nearby);
 
 	void set_failover_type(enum MetadataFailoverType type)
 	{

--- a/src/PolarisPolicies.h
+++ b/src/PolarisPolicies.h
@@ -66,34 +66,29 @@ private:
 	enum NearbyMatchLevelType nearby_max_match_level;
 	short nearby_unhealthy_percentage;
 	bool nearby_enable_recover_all;
-	bool strict_nearby;
+	bool nearby_strict_nearby;
 
 public:
 	PolarisPolicyConfig(const std::string& policy_name,
 						const PolarisConfig& conf);
 
-	const std::string& get_policy_name() const
+	void set_rule_base_router(bool enable)
 	{
-		return this->policy_name;
-	}
+		this->enable_rule_base_router = enable;
 
-	void set_rule_base_router(bool flag)
-	{
-		this->enable_rule_base_router = flag;
-
-		if (flag)
+		if (enable)
 			this->enable_dst_meta_router = false;
 	}
 
-	void set_dst_meta_router(bool flag)
+	void set_dst_meta_router(bool enable)
 	{
-		this->enable_dst_meta_router = flag;
+		this->enable_dst_meta_router = enable;
 
-		if (flag)
+		if (enable)
 			this->enable_rule_base_router = false;
 	}
 
-	void set_nearby_based_router(bool flag, std::string match_level,
+	void set_nearby_based_router(bool enable, std::string match_level,
 								 std::string max_match_level, short percentage,
 								 bool enable_recover_all, bool strict_nearby);
 
@@ -115,6 +110,9 @@ public:
 		return this->metadata;
 	}
 	bool get_healthy() const { return this->healthy; }
+	const std::string& get_region() const { return this->region; }
+	const std::string& get_zone() const { return this->zone; }
+	const std::string& get_campus() const { return this->campus; }
 
 public:
 	PolarisInstanceParams(const struct instance *inst,
@@ -128,6 +126,9 @@ private:
 	bool isolate;
 	std::string logic_set;
 	std::string service_namespace;
+	std::string region;
+	std::string zone;
+	std::string campus;
 	std::map<std::string, std::string> metadata;
 };
 
@@ -189,8 +190,11 @@ private:
 			const std::vector<struct destination_bound *>& bounds,
 			const std::vector<std::vector<EndpointAddress *>>& subsets);
 
-	EndpointAddress *get_one(const std::vector<EndpointAddress *>& instances,
+	EndpointAddress *get_one(std::vector<EndpointAddress *>& instances,
 							 WFNSTracing *tracing);
+	bool nearby_router_filter(std::vector<EndpointAddress *>& instances);
+	bool nearby_match_level(const PolarisInstanceParams *params,
+							NearbyMatchLevelType level);
 
 	bool split_fragment(const char *fragment,
 						std::string& caller_name,


### PR DESCRIPTION
主要改动：
1. 支持`就近路由`选取策略，是在select()中，`规则路由` or `元数据路由`之后进行的一个过滤，剩下的会继续进行get_one()；
2. 增加PolarisConfig文件中读取“strictNearby”的配置，用于是否严格就近路由；
3. 修复PolarisInstance拷贝赋值函数需要判断this的问题；

P.S. 最近的改动比较多，下周会补充单测和github平台上的自动ci流程。